### PR TITLE
Add runtime option providers for string config fields

### DIFF
--- a/src/Core/Config/Attributes/OptionProviderAttribute.cs
+++ b/src/Core/Config/Attributes/OptionProviderAttribute.cs
@@ -1,0 +1,30 @@
+using System;
+
+namespace TerrariaModder.Core.Config
+{
+    /// <summary>
+    /// Resolves a string config property's allowed options from a method at runtime.
+    ///
+    /// This complements <see cref="OptionsAttribute"/> for cases where the valid
+    /// option list is not known at compile time, such as assets discovered during
+    /// mod initialisation or values supplied by another registry.
+    ///
+    /// The provider method must be parameterless and return either string[] or any
+    /// <see cref="System.Collections.Generic.IEnumerable{T}"/> of string values.
+    /// It may be static or an instance method on the <see cref="ModConfig"/> subclass.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Property, AllowMultiple = false)]
+    public sealed class OptionProviderAttribute : Attribute
+    {
+        /// <summary>
+        /// Name of the parameterless method on the config type that returns the
+        /// current option list.
+        /// </summary>
+        public string MethodName { get; }
+
+        public OptionProviderAttribute(string methodName)
+        {
+            MethodName = methodName;
+        }
+    }
+}

--- a/src/Core/Config/ConfigPropertyMeta.cs
+++ b/src/Core/Config/ConfigPropertyMeta.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Reflection;
 
 namespace TerrariaModder.Core.Config
@@ -45,6 +46,13 @@ namespace TerrariaModder.Core.Config
         /// <summary>Allowed options for [Options] string fields.</summary>
         public string[] Options { get; internal set; }
 
+        /// <summary>
+        /// Optional provider for dynamic string options.
+        /// When present, callers should prefer <see cref="GetOptions"/> over reading
+        /// <see cref="Options"/> directly so late-bound values stay up to date.
+        /// </summary>
+        internal Func<ModConfig, string[]> OptionsProvider { get; set; }
+
         /// <summary>Legacy names mapped to this property (from [FormerlySerializedAs]).</summary>
         public string[] FormerNames { get; internal set; }
 
@@ -53,6 +61,21 @@ namespace TerrariaModder.Core.Config
 
         /// <summary>Get the current value from a config instance.</summary>
         public object GetValue(ModConfig config) => Property.GetValue(config);
+
+        /// <summary>
+        /// Get allowed options for this property.
+        /// Returns a fresh array when backed by a dynamic provider so callers see
+        /// the latest runtime state instead of a startup-time snapshot.
+        /// </summary>
+        public string[] GetOptions(ModConfig config)
+        {
+            if (OptionsProvider != null)
+            {
+                return OptionsProvider(config) ?? Array.Empty<string>();
+            }
+
+            return Options ?? Array.Empty<string>();
+        }
 
         /// <summary>Set a value on a config instance (clamps numerics to range).</summary>
         public void SetValue(ModConfig config, object value)

--- a/src/Core/Config/ModConfig.cs
+++ b/src/Core/Config/ModConfig.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Reflection;
 using TerrariaModder.Core.Logging;
 
@@ -131,6 +132,15 @@ namespace TerrariaModder.Core.Config
                     Options = prop.GetCustomAttribute<OptionsAttribute>()?.Values
                 };
 
+                // Resolve the provider once when metadata is built, but invoke it later
+                // whenever the UI or APIs need the current option list. This keeps the
+                // reflection cost low without freezing dynamic values at startup.
+                var optionProvider = prop.GetCustomAttribute<OptionProviderAttribute>();
+                if (optionProvider != null)
+                {
+                    meta.OptionsProvider = BuildOptionsProvider(prop, optionProvider);
+                }
+
                 // Scope: explicit [Server] or [Client]; untagged defaults to Client
                 if (prop.GetCustomAttribute<ServerAttribute>() != null)
                     meta.Scope = ConfigScope.Server;
@@ -148,6 +158,54 @@ namespace TerrariaModder.Core.Config
             }
 
             return result.AsReadOnly();
+        }
+
+        private Func<ModConfig, string[]> BuildOptionsProvider(PropertyInfo prop, OptionProviderAttribute attr)
+        {
+            if (prop.PropertyType != typeof(string))
+            {
+                Log?.Warn($"[{ModId}] [OptionProvider] Property '{prop.Name}' must be a string to use dynamic options.");
+                return null;
+            }
+
+            if (string.IsNullOrWhiteSpace(attr.MethodName))
+            {
+                Log?.Warn($"[{ModId}] [OptionProvider] Property '{prop.Name}' is missing a provider method name.");
+                return null;
+            }
+
+            const BindingFlags flags = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.Instance;
+            var method = GetType().GetMethod(attr.MethodName, flags, null, Type.EmptyTypes, null);
+            if (method == null)
+            {
+                Log?.Warn($"[{ModId}] [OptionProvider] Method '{attr.MethodName}' was not found for property '{prop.Name}'.");
+                return null;
+            }
+
+            if (!typeof(IEnumerable<string>).IsAssignableFrom(method.ReturnType))
+            {
+                Log?.Warn($"[{ModId}] [OptionProvider] Method '{attr.MethodName}' for property '{prop.Name}' must return IEnumerable<string>.");
+                return null;
+            }
+
+            return config =>
+            {
+                try
+                {
+                    object target = method.IsStatic ? null : config;
+                    var result = method.Invoke(target, null) as IEnumerable<string>;
+
+                    // Normalize provider output so every caller gets the same contract:
+                    // no null/blank values and no duplicates that would create noisy or
+                    // ambiguous selector entries in the config UI.
+                    return result?.Where(value => !string.IsNullOrWhiteSpace(value)).Distinct().ToArray() ?? Array.Empty<string>();
+                }
+                catch (Exception ex)
+                {
+                    Log?.Warn($"[{ModId}] [OptionProvider] Method '{attr.MethodName}' for property '{prop.Name}' failed: {ex.Message}");
+                    return Array.Empty<string>();
+                }
+            };
         }
 
         // Called by ConfigManager to apply migrated raw values.

--- a/src/Core/UI/ModMenu.cs
+++ b/src/Core/UI/ModMenu.cs
@@ -785,7 +785,10 @@ namespace TerrariaModder.Core.UI
             {
                 DrawFloatField(valueX, y, valueWidth, currentValue, meta, config, modId);
             }
-            else if (t == typeof(string) && meta.Options != null && meta.Options.Length > 0)
+            // String fields with either static [Options] or a runtime option provider
+            // render as left/right selectors. We query on demand so mods can surface
+            // values discovered after initial config metadata construction.
+            else if (t == typeof(string) && meta.GetOptions(config).Length > 0)
             {
                 DrawEnumField(valueX, y, valueWidth, currentValue, meta, config, modId);
             }
@@ -1011,7 +1014,9 @@ namespace TerrariaModder.Core.UI
         private static void DrawEnumField(int x, int y, int width, object value, Config.ConfigPropertyMeta meta, Config.ModConfig config, string modId)
         {
             string currentVal = value?.ToString() ?? "";
-            var options = meta.Options != null ? new List<string>(meta.Options) : new List<string>();
+            // Re-fetch options each frame so a selector can reflect live registries or
+            // lazily loaded content without needing the config screen to be rebuilt.
+            var options = new List<string>(meta.GetOptions(config));
             int currentIndex = options.IndexOf(currentVal);
             if (currentIndex < 0) currentIndex = 0;
 

--- a/src/DebugTools/DebugHttpServer.cs
+++ b/src/DebugTools/DebugHttpServer.cs
@@ -2322,10 +2322,13 @@ namespace DebugTools
 
                 if (meta.Min.HasValue) pairs.Add(JsonPair("min", meta.Min.Value));
                 if (meta.Max.HasValue) pairs.Add(JsonPair("max", meta.Max.Value));
-                if (meta.Options != null && meta.Options.Length > 0)
+                // Export the resolved option list, not just the static [Options] values,
+                // so external tooling sees the same dynamic selector choices as the UI.
+                var options = meta.GetOptions(config);
+                if (options.Length > 0)
                 {
                     var opts = new List<string>();
-                    foreach (var opt in meta.Options)
+                    foreach (var opt in options)
                         opts.Add($"\"{EscapeJson(opt)}\"");
                     pairs.Add(JsonArray("options", opts));
                 }
@@ -2364,16 +2367,18 @@ namespace DebugTools
                 if (!raw.TryGetValue("value", out object rawValue))
                     return JsonObject(JsonPair("success", false), JsonPair("error", "Missing 'value' field"));
 
-                // Validate string Options constraint before setting
-                if (target.Options != null && target.Options.Length > 0 && target.PropertyType == typeof(string))
+                // Validate against the resolved option list so HTTP config writes obey
+                // both static [Options] and runtime-provided choices.
+                var options = target.GetOptions(config);
+                if (options.Length > 0 && target.PropertyType == typeof(string))
                 {
                     string strVal = rawValue?.ToString() ?? "";
                     bool found = false;
-                    foreach (var opt in target.Options)
+                    foreach (var opt in options)
                         if (opt == strVal) { found = true; break; }
                     if (!found)
                         return JsonObject(JsonPair("success", false),
-                            JsonPair("error", $"Value '{strVal}' is not a valid option for '{propName}'. Allowed: {string.Join(", ", target.Options)}"));
+                            JsonPair("error", $"Value '{strVal}' is not a valid option for '{propName}'. Allowed: {string.Join(", ", options)}"));
                 }
 
                 // Check scope mismatch (set in memory but warn about persistence)


### PR DESCRIPTION
# Add runtime option providers for string config fields

This change adds support for dynamic option lists in the config system.

Today, string config selectors only work when the valid values are known at compile time via `[Options(...)]`. That works well for fixed enum-like settings, but it breaks down for values that are discovered at runtime, such as fonts, assets, registry entries, or other data populated after mod initialization begins.

This PR introduces a new attribute, `OptionProviderAttribute`, that allows a string config property to supply its allowed values from a parameterless method on the config class. The provider method can be static or instance-based and must return `IEnumerable<string>` or `string[]`.

## What changed

- Added `OptionProviderAttribute` to the config system.
- Extended `ConfigPropertyMeta` with `GetOptions(config)`, which resolves either:
  - static values from `[Options(...)]`, or
  - dynamic values from an option provider.
- Updated `ModConfig` metadata construction to detect and validate `OptionProviderAttribute`.
- Added guardrails and logging for invalid provider usage:
  - property must be `string`
  - provider method name must be present
  - provider method must exist
  - provider method must be parameterless
  - provider method must return `IEnumerable<string>`
- Normalized provider output before exposing it:
  - removes null/blank values
  - removes duplicates
- Updated the in-game config UI so string selectors use the resolved option list at render time instead of only static metadata.
- Updated the debug HTTP config API so exported options and server-side validation use the same resolved option list as the in-game UI.

## Why this is needed

The motivating case is a mod config field whose valid values are populated from a runtime registry. In this case, FlexUI exposes a font setting, but the available fonts are discovered from loaded content and registered at runtime. The existing `[Options(...)]` attribute cannot express that, so the config menu only showed the default/current value instead of the real available font list.

By resolving options at use time rather than only when config metadata is first built, the framework can support late-bound config values without requiring the config screen or metadata cache to be rebuilt.

## Design notes

- This is additive and backwards-compatible.
- Existing `[Options(...)]` behavior remains unchanged.
- Dynamic options are only supported for `string` properties, which matches the current selector model in the config UI.
- The option provider is resolved once during metadata construction, but invoked later whenever options are needed. This keeps reflection overhead low while still allowing live runtime values.
- Both the UI and HTTP API use the same `GetOptions(config)` path so they stay behaviorally consistent.

## Example usage

Static options still work as before:

```csharp
[Client, Label("Frame Rate Mode"), Options("VSync", "Capped", "Uncapped")]
public string FrameRateMode { get; set; } = "VSync";
```

Dynamic options now work like this:

```csharp
[Client, Label("UI Font"), OptionProvider(nameof(GetFontOptions))]
public string Font { get; set; } = "vanilla";

private static string[] GetFontOptions()
{
    return FontRegistry.RegisteredNames
        .Prepend("vanilla")
        .ToArray();
}
```

## Behavioral result

- Config fields backed by `[Options(...)]` continue to render as left/right selectors.
- Config fields backed by `[OptionProvider(...)]` now render the same way, but with values resolved from live runtime state.
- HTTP config tooling now receives the same option list the in-game UI uses and rejects invalid writes against that same list.