### PR TITLE
fix(ui): Scale scissor rectangle by UI scale

### DIFF
--- a/src/Core/UI/UIRenderer.cs
+++ b/src/Core/UI/UIRenderer.cs
@@ -476,7 +476,18 @@ namespace TerrariaModder.Core.UI
                 _savedRasterizerState = _graphicsDevice.RasterizerState;
 
                 // Set new scissor rect
-                _graphicsDevice.ScissorRectangle = new Rectangle(x, y, width, height);
+                // The scissor rectangle is in physical pixels, but x/y/width/height are in
+                // UI-space (pre-UIScale). Multiply by UIScale to get the correct pixel bounds.
+                // Without this, at >100% scale the clip region is too small and sits in the
+                // wrong place, cutting off content and icons near the right/bottom edges.
+                float clipScale = GetUIScale();
+                if (clipScale <= 0f) clipScale = 1f;
+                _graphicsDevice.ScissorRectangle = new Rectangle(
+                    (int)(x * clipScale),
+                    (int)(y * clipScale),
+                    (int)(width * clipScale),
+                    (int)(height * clipScale)
+                );
 
                 // Set rasterizer state with scissor test enabled
                 _graphicsDevice.RasterizerState = _rasterizerStateScissor;


### PR DESCRIPTION
fixes https://github.com/Inidar1/terraria-modder/issues/11

## Which mod(s)?

Core

## How to test

Set UI scale to anything but 100%, open storage hub, switch to shimmer tab(have it unlocked and some shimmerable items)

## Checklist

- [x] `build.bat` passes
- [x] Tested in-game with `TerrariaInjector.exe`
- [x] No errors in `Terraria/TerrariaModder/core/logs/terrariamodder.log`
- [x] Other mods still work (if Core was changed)

## Screenshots

before:
<img width="1416" height="756" alt="image" src="https://github.com/user-attachments/assets/767998fa-cdd4-4a34-8211-f906413d82e2" />

after:
<img width="1456" height="769" alt="image" src="https://github.com/user-attachments/assets/487f3e36-0e8f-4443-9dd0-ea44834165ff" />

