### PR TITLE
fix(core): CaptureManagerGuard crashes the game on Mono (Linux/macOS native Terraria)

### DIFF
--- a/src/Core/Patches/CaptureManagerGuard.cs
+++ b/src/Core/Patches/CaptureManagerGuard.cs
@@ -23,16 +23,73 @@ namespace TerrariaModder.Core.Patches
     ///    (IsCapturing, DrawTick, Dispose, GetProgress, Capture)
     ///
     /// Applied during LoadPlugins() — before Main.Initialize() runs.
+    ///
+    /// Mono caveat: on the Mono runtime (Linux/macOS native Terraria), Harmony.Patch()
+    /// eagerly runs the target type's static constructor at patch time. Applying this
+    /// guard before a GraphicsDevice exists therefore *causes* the exact cctor poisoning
+    /// it is meant to prevent. On Mono the patch is deferred until OnGameReady(), when
+    /// Main.instance.GraphicsDevice is available and running the cctor is harmless.
     /// </summary>
     internal static class CaptureManagerGuard
     {
         private static ILogger _log;
         private static FieldInfo _cameraField;
+        private static bool _deferredPending;
 
         public static void Apply(ILogger logger)
         {
             _log = logger;
 
+            bool isMono = Type.GetType("Mono.Runtime") != null;
+            if (isMono && !GraphicsDeviceReady())
+            {
+                // Patching now would eagerly run CaptureManager's cctor with a null
+                // GraphicsDevice, permanently poisoning the type. Wait for OnGameReady.
+                _deferredPending = true;
+                _log?.Info("CaptureManagerGuard: deferred until OnGameReady (Mono runs static ctors eagerly on patch; GraphicsDevice not ready yet)");
+                return;
+            }
+
+            ApplyCore();
+        }
+
+        /// <summary>
+        /// Applies a deferred guard (Mono only). Called from PluginLoader.OnGameReady(),
+        /// after Main.Initialize() has created the GraphicsDevice. No-op if the guard
+        /// was already applied in Apply().
+        /// </summary>
+        public static void ApplyDeferred()
+        {
+            if (!_deferredPending)
+                return;
+            _deferredPending = false;
+
+            if (!GraphicsDeviceReady())
+            {
+                // Headless/dedicated-server on Mono: no device will ever exist, and
+                // patching would poison the type. Leave vanilla behavior in place.
+                _log?.Warn("CaptureManagerGuard: skipped — GraphicsDevice still unavailable at OnGameReady (headless?)");
+                return;
+            }
+
+            ApplyCore();
+        }
+
+        private static bool GraphicsDeviceReady()
+        {
+            try
+            {
+                // Game.GraphicsDevice can throw before device creation; treat as not ready.
+                return Main.instance?.GraphicsDevice != null;
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
+        private static void ApplyCore()
+        {
             try
             {
                 var captureManagerType = typeof(Main).Assembly.GetType("Terraria.Graphics.Capture.CaptureManager");

--- a/src/Core/Patches/CaptureManagerGuard.cs
+++ b/src/Core/Patches/CaptureManagerGuard.cs
@@ -136,15 +136,20 @@ namespace TerrariaModder.Core.Patches
 
         private static void PatchMethod(Harmony harmony, Type type, string methodName, string prefixName)
         {
-            var method = type.GetMethod(methodName,
-                BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
-            if (method != null)
+            // GetMethod(name) throws AmbiguousMatchException for overloaded methods
+            // (e.g. Capture() and Capture(CaptureSettings)) — patch every overload.
+            var prefix = new HarmonyMethod(typeof(CaptureManagerGuard).GetMethod(prefixName,
+                BindingFlags.NonPublic | BindingFlags.Static));
+            bool found = false;
+            foreach (var method in type.GetMethods(
+                BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance))
             {
-                harmony.Patch(method, prefix: new HarmonyMethod(
-                    typeof(CaptureManagerGuard).GetMethod(prefixName,
-                        BindingFlags.NonPublic | BindingFlags.Static)));
+                if (method.Name != methodName)
+                    continue;
+                harmony.Patch(method, prefix: prefix);
+                found = true;
             }
-            else
+            if (!found)
             {
                 _log?.Debug($"CaptureManagerGuard: {methodName} not found, skipping");
             }

--- a/src/Core/PluginLoader.cs
+++ b/src/Core/PluginLoader.cs
@@ -903,6 +903,10 @@ namespace TerrariaModder.Core
         {
             _log?.Info("Lifecycle: OnGameReady — applying deferred patches");
 
+            // On Mono, CaptureManagerGuard defers its Harmony patches until the
+            // GraphicsDevice exists (see CaptureManagerGuard for details). No-op elsewhere.
+            Patches.CaptureManagerGuard.ApplyDeferred();
+
             // Start HTTP management API for dedicated server (if key configured)
             // Skip if already started during LoadPlugins()
             if (IsDedicatedServer)


### PR DESCRIPTION
## Problem

On the Mono runtime (native Linux/macOS Terraria launched via `mono TerrariaInjector.exe`), the game crashes at startup with:

```
System.TypeInitializationException: The type initializer for 'Terraria.Graphics.Capture.CaptureManager' threw an exception.
 ---> System.ArgumentNullException: Value cannot be null. Parameter name: graphicsDevice
  at Microsoft.Xna.Framework.Graphics.SpriteBatch..ctor (...)
  at Terraria.Graphics.Capture.CaptureCamera..ctor (...)
  ...
  at Terraria.Lighting.Initialize () ...
```

and `terrariamodder.log` shows `CaptureManagerGuard failed to apply: The type initializer for 'Terraria.Graphics.Capture.CaptureManager' threw an exception.` just before.

**Root cause:** on Mono, `Harmony.Patch()` eagerly runs the target type's static constructor at patch time. `CaptureManagerGuard.Apply()` runs during `LoadPlugins()` (inside `Main`'s constructor), so patching forces `CaptureManager`'s cctor to run while `Main.instance.GraphicsDevice` is still null. The cctor throws, the `TypeInitializationException` is cached permanently, and the game dies later in `Lighting.Initialize()` — the guard *causes* the exact poisoning it exists to prevent. (On Windows .NET Framework, patching does not trigger the cctor, so this never reproduces there.)

## Fix

1. **Defer on Mono** (`9f38956`): if running on Mono and no GraphicsDevice exists yet, `Apply()` records the request and returns; `PluginLoader.OnGameReady()` calls the new `CaptureManagerGuard.ApplyDeferred()`, at which point the device exists and running the cctor is harmless. Windows behavior is unchanged (patches still apply during `LoadPlugins()`). If the device never appears (headless Mono server), patching is skipped with a warning instead of poisoning the type.

2. **Patch all overloads** (`3b3a70e`): while verifying the fix, the guard then failed with `CaptureManagerGuard failed to apply: Ambiguous match found.` — `Type.GetMethod(name, flags)` throws `AmbiguousMatchException` because `CaptureManager.Capture` is overloaded. This looks like it would have prevented the guard from ever applying on any platform. `PatchMethod` now enumerates `GetMethods()` and patches every overload with the given name; the existing `object __instance`-only prefixes work for any signature.

## Verification

Tested on Terraria 1.4.5.6 native Linux (FNA 26.3.0.0, Mono 6.12, Arch Linux):

- Before: startup crash dialog with the `TypeInitializationException` above.
- After: `terrariamodder.log` shows
  ```
  CaptureManagerGuard: deferred until OnGameReady (Mono runs static ctors eagerly on patch; GraphicsDevice not ready yet)
  Lifecycle: OnGameReady — applying deferred patches
  CaptureManagerGuard applied — ctor finalizer + 5 null-camera guards
  ```
  and the game reaches the menu and plays normally.

(For anyone else running the Linux build: mod DLLs built against the Windows XNA assembly names also need their references retargeted to FNA before they load, but that's orthogonal to this fix.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
