### PR TITLE
fix(StorageHub): block game input during tab search and release on close

### DIFF
--- a/src/StorageHub/UI/StorageHubUI.cs
+++ b/src/StorageHub/UI/StorageHubUI.cs
@@ -167,7 +167,7 @@ namespace StorageHub.UI
             }
             else
             {
-                _searchInput.Unfocus();
+                ReleaseSearchFocus();
                 // Unregister panel bounds - this automatically disables mouse blocking if no other panels
                 UIRenderer.UnregisterPanelBounds("storage-hub");
             }
@@ -181,7 +181,7 @@ namespace StorageHub.UI
             if (_isOpen)
             {
                 _isOpen = false;
-                _searchInput.Unfocus();
+                ReleaseSearchFocus();
                 UIRenderer.UnregisterPanelBounds("storage-hub");
                 UIRenderer.CloseInventory();
             }
@@ -195,9 +195,21 @@ namespace StorageHub.UI
             if (_isOpen)
             {
                 _isOpen = false;
-                _searchInput.Unfocus();
+                ReleaseSearchFocus();
                 UIRenderer.UnregisterPanelBounds("storage-hub");
             }
+        }
+
+        private void ReleaseSearchFocus()
+        {
+            _searchInput.Unfocus();
+            _craftTab.UnfocusSearch();
+            _recipesTab.UnfocusSearch();
+        }
+
+        private bool IsAnySearchFocused()
+        {
+            return _searchInput.IsFocused || _craftTab.IsSearchFocused || _recipesTab.IsSearchFocused;
         }
 
         /// <summary>
@@ -240,8 +252,8 @@ namespace StorageHub.UI
         {
             if (!_isOpen) return;
 
-            // Handle Escape to close storage hub (unless search is focused)
-            if (!_searchInput.IsFocused)
+            // Handle Escape to close storage hub (unless a search field is focused)
+            if (!IsAnySearchFocused())
             {
                 if (InputState.IsKeyJustPressed(KeyCode.Escape))
                 {

--- a/src/StorageHub/UI/StorageHubUI.cs
+++ b/src/StorageHub/UI/StorageHubUI.cs
@@ -53,13 +53,13 @@ namespace StorageHub.UI
         public string ActiveTabName => _activeTab >= 0 && _activeTab < TabNames.Length ? TabNames[_activeTab] : "?";
         public void SetActiveTab(int tab)
         {
-            if (tab >= 0 && tab < TabNames.Length) _activeTab = tab;
+            ChangeActiveTab(tab);
         }
         public void SetActiveTab(string name)
         {
             for (int i = 0; i < TabNames.Length; i++)
                 if (string.Equals(TabNames[i], name, System.StringComparison.OrdinalIgnoreCase))
-                { _activeTab = i; return; }
+                { ChangeActiveTab(i); return; }
         }
 
         // UI Components
@@ -131,7 +131,7 @@ namespace StorageHub.UI
             // Set up callbacks
             _recipesTab.OnJumpToCraft = (itemId) =>
             {
-                _activeTab = TabCraft;
+                ChangeActiveTab(TabCraft);
                 _craftTab.NavigateToItem(itemId);
             };
 
@@ -210,6 +210,18 @@ namespace StorageHub.UI
         private bool IsAnySearchFocused()
         {
             return _searchInput.IsFocused || _craftTab.IsSearchFocused || _recipesTab.IsSearchFocused;
+        }
+
+        private void ChangeActiveTab(int tab)
+        {
+            if (tab < 0 || tab >= TabNames.Length || tab == _activeTab)
+                return;
+
+            // A hidden TextInput cannot process Escape, so release its focus before
+            // switching tabs to keep keyboard blocking and focus state in sync.
+            ReleaseSearchFocus();
+            _activeTab = tab;
+            _needsRefresh = true;
         }
 
         /// <summary>
@@ -380,8 +392,7 @@ namespace StorageHub.UI
             var newTab = TabBar.Draw(x, tabY, PanelWidth, TabNames, _activeTab);
             if (newTab != _activeTab)
             {
-                _activeTab = newTab;
-                _needsRefresh = true;
+                ChangeActiveTab(newTab);
                 // Don't reset scroll - preserve scroll position per tab
                 // Each tab maintains its own scroll state internally
             }

--- a/src/StorageHub/UI/Tabs/CraftTab.cs
+++ b/src/StorageHub/UI/Tabs/CraftTab.cs
@@ -93,7 +93,15 @@ namespace StorageHub.UI.Tabs
             _config = config;
             _modConfig = modConfig;
             _executor = new CraftingExecutor(log, storage);
+            _searchBar.KeyBlockId = "storage-hub-search";
         }
+
+        /// <summary>
+        /// Release search focus and keyboard input block when the panel closes.
+        /// </summary>
+        public void UnfocusSearch() => _searchBar.Unfocus();
+
+        public bool IsSearchFocused => _searchBar.IsFocused;
 
         /// <summary>
         /// Mark data as needing refresh.

--- a/src/StorageHub/UI/Tabs/RecipesTab.cs
+++ b/src/StorageHub/UI/Tabs/RecipesTab.cs
@@ -82,7 +82,15 @@ namespace StorageHub.UI.Tabs
             _recipeIndex = recipeIndex;
             _checker = checker;
             _config = config;
+            _searchBar.KeyBlockId = "storage-hub-search";
         }
+
+        /// <summary>
+        /// Release search focus and keyboard input block when the panel closes.
+        /// </summary>
+        public void UnfocusSearch() => _searchBar.Unfocus();
+
+        public bool IsSearchFocused => _searchBar.IsFocused;
 
         /// <summary>
         /// Mark data as needing refresh.


### PR DESCRIPTION
Tab search fields in Craft and Recipes did not set KeyBlockId, so typed text moved the player (or could accidentally throw item).

## What changed

- Set `KeyBlockId = "storage-hub-search"` on the Craft and Recipes search fields.
- Release all search focus when the Storage Hub closes.
- Route tab changes through a shared handler that releases search focus before hiding the active tab.
- Prevent hidden search fields from keeping keyboard input blocked or intercepting Escape or F5.

## Which mod(s)?

- StorageHub only
- Core unchanged

## How to test

- In game, open Storage Hub (F5)

### Primary test

- In Recipes or Craft tab, click the search bar and type text
- Confirm the player does not move or jump or anything else
- Close Storage Hub -> player control should return immediately

### Secondary test
- Focus a search field in Items, Crafting, or Recipes, then switch to another tab
  - Confirm keyboard controls are restored
  - Confirm Escape closes the Storage Hub normally

## Checklist

- [ ] `build.bat` passes [ dotnet build src/StorageHub/StorageHub.csproj -c Release passes (full build.bat fails on Core due to unrelated Terraria API mismatch) ]
- [x] Tested in-game with `TerrariaInjector.exe`
- [x] No errors in `Terraria/TerrariaModder/core/logs/terrariamodder.log`
- [x] Core wasn't changed

