### PR TITLE
BugFix (Core & Core.Server): Terraria.Item.NewItem convert Vector2 position (top left corner) to Vector2 center and use new TagDamageChanges

### DIFF
--- a/src/Core/PluginLoader.cs
+++ b/src/Core/PluginLoader.cs
@@ -175,7 +175,7 @@ namespace TerrariaModder.Core
     /// </summary>
     public static class PluginLoader
     {
-        public const string FrameworkVersion = "0.4.0";
+        public const string FrameworkVersion = "0.4.1";
 
         // Static constructor — runs once, before any other PluginLoader code.
         // Installs global unhandled exception handler so Windows error dialogs

--- a/src/Core/Server/DedServProxy.cs
+++ b/src/Core/Server/DedServProxy.cs
@@ -183,7 +183,7 @@ namespace TerrariaModder.Core.Server
         {
             if (!_isDedServ)
             {
-                try { Terraria.Item.NewItem(null, pos, width, height, itemId, stack, false, prefix); return; } catch { }
+                try { Terraria.Item.NewItem(null, (int)pos.X, (int)pos.Y, width, height, itemId, stack, false, prefix); return; } catch { }
             }
             try
             {

--- a/src/Core/Server/DedServProxy.cs
+++ b/src/Core/Server/DedServProxy.cs
@@ -29,8 +29,8 @@ namespace TerrariaModder.Core.Server
         private static FieldInfo _playerField;    // Main.player (Player[])
         private static FieldInfo _itemField;      // Main.item   (Item[])
 
-        // Item.NewItem method (the overload used for spawning)
-        // NewItem(IEntitySource, Vector2, int, int, int, int, bool, int)
+        // Item.NewItem method (the ergonomic overload used for spawning)
+        // NewItem(IEntitySource, Vector2, int, int, int, NewItemOwnership, Vector2?, NewItemModifier, bool)
         private static MethodInfo _itemNewItem;
 
         // NetMessage.TrySendData for packet 32 (SyncChestItem) and packet 21 (ItemDrop)
@@ -63,7 +63,7 @@ namespace TerrariaModder.Core.Server
                 var itemType = asm.GetType("Terraria.Item");
                 if (itemType != null)
                 {
-                    // NewItem(IEntitySource source, Vector2 pos, int Width, int Height, int Type, int Stack=1, bool noBroadcast=false, int prefixGiven=0)
+                    // NewItem(IEntitySource source, Vector2 center, int type, int stack = 1, int prefix = 0, NewItemOwnership ownership = NewItemOwnership.None, Vector2? velocity = null, NewItemModifier modifier = null, bool noBroadcast = false)
                     foreach (var m in itemType.GetMethods(BindingFlags.Public | BindingFlags.Static))
                     {
                         if (m.Name != "NewItem") continue;
@@ -181,9 +181,10 @@ namespace TerrariaModder.Core.Server
         /// <summary>Spawn an item drop in the world (server-safe).</summary>
         public static void ItemNewItem(Microsoft.Xna.Framework.Vector2 pos, int width, int height, int itemId, int stack, int prefix)
         {
+            var center = new Microsoft.Xna.Framework.Vector2(pos.X + width / 2, pos.Y + height / 2);
             if (!_isDedServ)
             {
-                try { Terraria.Item.NewItem(null, (int)pos.X, (int)pos.Y, width, height, itemId, stack, false, prefix); return; } catch { }
+                try { Terraria.Item.NewItem(null, center, itemId, stack, prefix); return; } catch { }
             }
             try
             {
@@ -193,13 +194,10 @@ namespace TerrariaModder.Core.Server
                     var args = new object[prms.Length];
                     for (int i = 0; i < args.Length; i++) args[i] = prms[i].HasDefaultValue ? prms[i].DefaultValue : null;
                     args[0] = null; // IEntitySource
-                    args[1] = pos;
-                    if (prms.Length > 2) args[2] = width;
-                    if (prms.Length > 3) args[3] = height;
-                    if (prms.Length > 4) args[4] = itemId;
-                    if (prms.Length > 5) args[5] = stack;
-                    if (prms.Length > 6) args[6] = false; // noBroadcast
-                    if (prms.Length > 7) args[7] = prefix;
+                    args[1] = center;
+                    if (prms.Length > 2) args[2] = itemId;
+                    if (prms.Length > 3) args[3] = stack;
+                    if (prms.Length > 4) args[4] = prefix;
                     _itemNewItem.Invoke(null, args);
                 }
             }

--- a/src/Core/TerrariaModder.Core.csproj
+++ b/src/Core/TerrariaModder.Core.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Version>0.4.0</Version>
+    <Version>0.4.1</Version>
     <TargetFramework>net48</TargetFramework>
     <LangVersion>latest</LangVersion>
     <OutputType>Library</OutputType>

--- a/src/DebugTools/manifest.json
+++ b/src/DebugTools/manifest.json
@@ -1,8 +1,8 @@
 ﻿{
   "id": "debug-tools",
   "name": "Debug Tools",
-  "version": "2.0.0",
-  "framework_version": ">=0.2.0",
+  "version": "2.0.1",
+  "framework_version": ">=0.4.1",
   "author": "Inidar",
   "description": "Debug HTTP server, in-game console, virtual input, window management, and game state API.",
   "entry_dll": "DebugTools.dll",

--- a/src/WhipStacking/TagPatches.cs
+++ b/src/WhipStacking/TagPatches.cs
@@ -174,7 +174,7 @@ namespace WhipStacking
         /// ModifyHit — Apply tag damage from ALL active whips on this NPC.
         /// </summary>
         public static bool ModifyHit_Prefix(TagEffectState __instance, Projectile optionalProjectile, NPC npcHit,
-            ref int damageDealt, ref bool crit)
+            ref TagDamageChanges tagDamageChanges)
         {
             if (!Enabled) return true;
             try
@@ -193,11 +193,11 @@ namespace WhipStacking
 
                     if (!entry.Effect.CanRunHitEffects(owner, optionalProjectile, npcHit)) continue;
 
-                    entry.Effect.ModifyTaggedHit(owner, optionalProjectile, npcHit, ref damageDealt, ref crit);
+                    entry.Effect.ModifyTaggedHit(owner, optionalProjectile, npcHit, ref tagDamageChanges);
 
                     if (entry.ProcTimeLeftOnNPC[npcIdx] > 0)
                     {
-                        entry.Effect.ModifyProcHit(owner, optionalProjectile, npcHit, ref damageDealt, ref crit);
+                        entry.Effect.ModifyProcHit(owner, optionalProjectile, npcHit, ref tagDamageChanges);
                     }
                 }
             }


### PR DESCRIPTION
## What changed

Fixing the Terraria.Item.NewItem parameters as it was using a Vector2 input for the position but according to the Terraria decompiled this should be two separate ints for X and Y:
https://aoki-lizlov.github.io/terraria-decompiled/db/d79/classTerraria_1_1Item_a7b106271887b8959b6c96043f2d79bd1.html#a7b106271887b8959b6c96043f2d79bd1

# Edit:
I then noticed that this gave an "Unergonomic" warning so I used ILSpy to find that there is an ergonomic override for this function as follows, which uses the center of the item instead of the top left corner:
```cs
NewItem(IEntitySource source, Vector2 center, int type, int stack = 1, int prefix = 0, NewItemOwnership ownership = NewItemOwnership.None, Vector2? velocity = null, NewItemModifier modifier = null, bool noBroadcast = false)
```

Then when running the build.bat, I encountered the following errors:
```
C:\Programming Projects\terraria-modder\src\WhipStacking\TagPatches.cs(196,34): error CS1501: No overload for method 'ModifyTaggedHit' takes 5 arguments
C:\Programming Projects\terraria-modder\src\WhipStacking\TagPatches.cs(200,38): error CS1501: No overload for method 'ModifyProcHit' takes 5 arguments
      ERROR: WhipStacking build failed
```

So I used ILSpy to find out that ModifyTaggedHit now takes 3 parameters instead of 5:
```cs
// Terraria, Version=1.4.5.8, Culture=neutral, PublicKeyToken=null
// Terraria.GameContent.Items.WhipTagEffect
public override void ModifyTaggedHit(Player owner, Projectile optionalProjectile, NPC npcHit, ref TagDamageChanges changes)
{
	changes.AddProjectileTagDamage = true;
	changes.AddedBaseDamage += TagDamage;
	if (changes.HighestAddedBaseDamage < TagDamage)
	{
		changes.HighestAddedBaseDamage = TagDamage;
	}
	if (Main.rand.Next(100) < CritChance)
	{
		changes.Crit = true;
	}
}
```

So I then looked into ModifyHit as that is the tag being patched and found that now includes the same TagDamageChanges:
```cs
// Terraria, Version=1.4.5.8, Culture=neutral, PublicKeyToken=null
// Terraria.GameContent.Items.TagEffectStack
public void ModifyHit(Projectile optionalProjectile, NPC npcHit, ref TagDamageChanges changes)
{
	for (int i = 0; i < _activeEffectCount; i++)
	{
		_effectStates[i].ModifyHit(optionalProjectile, npcHit, ref changes);
	}
}
```

So I simply passed through the TagDamageChanges instead of damageDealt and crit, then the build.bat passed successfully.

## Which mod(s)?

Core and Core.Server

## How to test

Try to compile the DebugTools mod and it will show:
```
C:\Programming Projects\terraria-modder>dotnet build src/DebugTools/DebugTools.csproj -c Release
TerrariaModder.Core net48 failed with 3 error(s) and 3 warning(s) (1.4s)
    C:\Programming Projects\terraria-modder\src\Core\Server\DedServProxy.cs(186,51): error CS1503: Argument 2: cannot convert from 'Microsoft.Xna.Framework.Vector2' to 'int'
    C:\Programming Projects\terraria-modder\src\Core\Server\DedServProxy.cs(186,86): error CS1503: Argument 7: cannot convert from 'bool' to 'int'
    C:\Programming Projects\terraria-modder\src\Core\Server\DedServProxy.cs(186,93): error CS1503: Argument 8: cannot convert from 'int' to 'bool'
```
After these changes it will successfully build DebugTools.

Then try to run build.bat and you will see the following errors:
```
C:\Programming Projects\terraria-modder\src\WhipStacking\TagPatches.cs(196,34): error CS1501: No overload for method 'ModifyTaggedHit' takes 5 arguments
C:\Programming Projects\terraria-modder\src\WhipStacking\TagPatches.cs(200,38): error CS1501: No overload for method 'ModifyProcHit' takes 5 arguments
      ERROR: WhipStacking build failed
```
## Checklist

- [X] `build.bat` passes
- [X] Tested in-game with `TerrariaInjector.exe`
- [X] No errors in `Terraria/TerrariaModder/core/logs/terrariamodder.log`
- [X] Other mods still work (if Core was changed) - Only tested with StorageHub

## Screenshots

<!-- If this changes UI, include before/after screenshots -->