### PR TITLE
Fix missing Invite Friends button

### DIFF
--- a/src/Core/Events/EventPatches.cs
+++ b/src/Core/Events/EventPatches.cs
@@ -1025,7 +1025,7 @@ namespace TerrariaModder.Core.Events
                 _log?.Info($"[H&P] Launching: {injectorPath} {args}");
 
                 // Launch the server process
-                var socialNetwork = typeof(Terraria.Social.SocialAPI).GetProperty("Network",
+                var socialNetwork = typeof(Terraria.Social.SocialAPI).GetField("Network",
                     BindingFlags.Public | BindingFlags.Static)?.GetValue(null);
                 if (socialNetwork != null)
                 {


### PR DESCRIPTION
## What changed

Fixed the **"Invite Friends"** multiplayer button to show on the multiplayer menu agian.

## Which mod(s)?

- TerrariaModder Core

## How to test

1. Run `build.bat`.
2. Launch Terraria using `TerrariaInjector.exe`.
3. Open the multiplayer menu.
4. Verify that the **"Invite Friends"** button is visible.
5. Click the button and verify that it works as expected.

## Checklist

- [ ] `build.bat` (doesn't pass because of the errors as of right now because of the errors. It does fix when I implement #18 in my src.)
- [x] Tested in-game with `TerrariaInjector.exe`
- [x] No errors in `Terraria/TerrariaModder/core/logs/terrariamodder.log`
- [x] Other mods still work (if Core was changed)

## Screenshots

<img width="1283" height="656" alt="image" src="https://github.com/user-attachments/assets/6bd204a7-4650-400d-babd-ba7b29c60bfb" />